### PR TITLE
Fix incorrect error message.

### DIFF
--- a/lib/bgg-api.rb
+++ b/lib/bgg-api.rb
@@ -117,7 +117,7 @@ class BggApi
         xml_data = response.body
         XmlSimple.xml_in(xml_data)
       else
-        raise "Received a #{response.code} at #{url} with #{params}"
+        raise Exception.new("Received a #{response.code} at #{url} with #{params}")
       end
     end
   end


### PR DESCRIPTION
You can only `raise` `Exception`s. We just wrap the string in an `Exception.new`